### PR TITLE
CFOS-91 fix: Reset atlas position only on atlas changes

### DIFF
--- a/client/src/components/Viewer.js
+++ b/client/src/components/Viewer.js
@@ -50,6 +50,7 @@ export const Viewer = (props) => {
     const currentAtlasStackHelperRef = useRef(null);
     const activityMapsStackHelpersRef = useRef({});
 
+    const previousAtlasIdRef = useRef(null);
     const activityMapsRef = useRef(activeActivityMaps);
 
     // On Mount
@@ -153,7 +154,12 @@ export const Viewer = (props) => {
     // On atlas changes
     useEffect(() => {
         if (activeAtlas) {
-            viewerHelper.updateCamera(containerRef.current, cameraRef.current, activeAtlas.stack);
+            const hasAtlasChanged = previousAtlasIdRef.current !== activeAtlas.id;
+
+            if(hasAtlasChanged){
+                viewerHelper.updateCamera(containerRef.current, cameraRef.current, activeAtlas.stack);
+                previousAtlasIdRef.current =activeAtlas.id;
+            }
 
             const targetStack = wireframeMode ? activeAtlas.wireframeStack : activeAtlas.stack;
 


### PR DESCRIPTION
The atlas position was being reset for any changes in the active atlas. With the current implementation, that will only happen when we effectively change atlas.

closes https://metacell.atlassian.net/jira/software/c/projects/CFOS/boards/45?selectedIssue=CFOS-91