### PR TITLE
CFOS-103 feat: Update slider logic

### DIFF
--- a/client/src/helpers/gradientHelper.js
+++ b/client/src/helpers/gradientHelper.js
@@ -1,6 +1,7 @@
 import {DEFAULT_COLOR_RANGE} from "../settings";
 
 export function getLUTGradients(colorRange, intensityRange, stackIntensityRange) {
+
     // Adjust intensityRange if it's outside stackIntensityRange
     if (intensityRange[0] < stackIntensityRange[0] || intensityRange[1] > stackIntensityRange[1]) {
         console.error('IntensityRange is outside StackIntensityRange. Using StackIntensityRange instead.');
@@ -8,7 +9,8 @@ export function getLUTGradients(colorRange, intensityRange, stackIntensityRange)
     }
 
     // Normalize the intensity range
-    const normalizedMinIntensity = (intensityRange[0] - stackIntensityRange[0]) / (stackIntensityRange[1] - stackIntensityRange[0]);
+    const epsilon = 0.01; // A small value to ensure min is non-inclusive
+    const normalizedMinIntensity = (intensityRange[0] - stackIntensityRange[0]) / (stackIntensityRange[1] - stackIntensityRange[0]) + epsilon;
     const normalizedMaxIntensity = (intensityRange[1] - stackIntensityRange[0]) / (stackIntensityRange[1] - stackIntensityRange[0]);
 
     let colorGradient, opacityGradient;
@@ -29,13 +31,13 @@ export function getLUTGradients(colorRange, intensityRange, stackIntensityRange)
             [0.0, 0, 0, 0, 0], // Transparent below intensity range
             [normalizedMinIntensity, ...colorRange[0], 1], // Min color at start of intensity range
             [normalizedMaxIntensity, ...colorRange[1], 1], // Max color at end of intensity range
-            [1.0, 0, 0, 0, 0] // Transparent above intensity range
+            [1.0, ...colorRange[1], 1] // Max should take everything above the max set.
         ];
         opacityGradient = [
             [0.0, 0], // Fully transparent below intensity range
             [normalizedMinIntensity, 1], // Opaque within intensity range
             [normalizedMaxIntensity, 1], // Opaque within intensity range
-            [1.0, 0] // Fully transparent above intensity range
+            [1.0, 1] // Max should take everything above the max set.
         ];
     }
 


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/CFOS-103

- Adds a small epsilon to ensure min is non-inclusive
- Updates gradient logic so that max color is applied to max range and higher values (opposed to higher values being transparent)


Before:
![image](https://github.com/MetaCell/cfos-visualizer/assets/19196034/dd28f11b-3d69-4464-a452-7ddd4c2ce72f)
![image](https://github.com/MetaCell/cfos-visualizer/assets/19196034/3a86ef9f-b3ee-4385-a26d-054a9cb9b840)


After:
![image](https://github.com/MetaCell/cfos-visualizer/assets/19196034/e6ee4812-6bcd-4025-be9f-6e1294df7c3b)
![image](https://github.com/MetaCell/cfos-visualizer/assets/19196034/7c40ca55-6cba-4f2b-a5ed-29ce36cdc723)

