### PR TITLE
CFOS-71 Drag and drop stack to change visibility order

### DIFF
--- a/client/src/components/ControlPanel.js
+++ b/client/src/components/ControlPanel.js
@@ -143,13 +143,16 @@ const ControlPanel = () => {
     const viewerObjects = getViewerObjectsData()
 
     const onReorder = (source, target) => {
+        // The activityMapOrder in the store is stored in a [lower priority, ..., higher priority] fashion
+        // but it's rendered in the table as [higer priority, ..., lower priority], so the layer the most visible
+        // is set as first element of the table.
+        // Consequently, when moving elements around, we need to first reverse the activityMapOrder to match
+        // the order of the table
+        // then, rebuilding the view order, we place the reordered map, then the first atlas, and finally, we reverse
+        // again to match the [lower priority, ..., higher priority] of the redux store for the viewer order
         const suborder = activityMapOrder.slice(1, activityMapOrder.length).reverse()
         move(suborder, source.index, target.index)
         dispatch(changeViewerOrder([...suborder, activityMapOrder[0]].reverse()))
-
-        // const suborder = activityMapOrder.slice(1, activityMapOrder.length)
-        // move(suborder, target.index, source.index)
-        // dispatch(changeViewerOrder([activityMapOrder[0], ...suborder]))
     }
 
     return (

--- a/client/src/components/ControlPanel.js
+++ b/client/src/components/ControlPanel.js
@@ -58,9 +58,10 @@ const styles = {
 };
 
 const move = (arr, fromIndex, toIndex) => {
-    var element = arr[fromIndex];
-    arr.splice(fromIndex, 1);
-    arr.splice(toIndex, 0, element);
+    var element = arr[fromIndex]
+    arr.splice(fromIndex, 1)
+    arr.splice(toIndex, 0, element)
+    return arr
 }
 
 const ControlPanel = () => {
@@ -142,9 +143,13 @@ const ControlPanel = () => {
     const viewerObjects = getViewerObjectsData()
 
     const onReorder = (source, target) => {
-        const suborder = activityMapOrder.slice(1, activityMapOrder.length)
+        const suborder = activityMapOrder.slice(1, activityMapOrder.length).reverse()
         move(suborder, source.index, target.index)
-        dispatch(changeViewerOrder([activityMapOrder[0], ...suborder]))
+        dispatch(changeViewerOrder([...suborder, activityMapOrder[0]].reverse()))
+
+        // const suborder = activityMapOrder.slice(1, activityMapOrder.length)
+        // move(suborder, target.index, source.index)
+        // dispatch(changeViewerOrder([activityMapOrder[0], ...suborder]))
     }
 
     return (

--- a/client/src/components/ControlPanel.js
+++ b/client/src/components/ControlPanel.js
@@ -96,7 +96,7 @@ const ControlPanel = () => {
             }
 
             // Rorder depending on the "order" from the store
-            viewerObjects.sort((a, b) => activityMapOrder.indexOf(a.id) - activityMapOrder.indexOf(b.id))
+            viewerObjects.sort((a, b) => activityMapOrder.indexOf(b.id) - activityMapOrder.indexOf(a.id))
 
             // Atlas should be the last entry in the array
             const atlasId = activeAtlas.id;

--- a/client/src/components/ControlPanel.js
+++ b/client/src/components/ControlPanel.js
@@ -6,7 +6,7 @@ import Table from "./Table";
 import {useSelector, useDispatch} from "react-redux";
 import {messages} from "../redux/constants";
 import CustomSlider from "./Slider";
-import {changeAllActivityMapsIntensityRange} from "../redux/actions";
+import {changeAllActivityMapsIntensityRange, changeViewerOrder} from "../redux/actions";
 
 
 const {headerBorderLeftColor, headingColor, accordianTextColor} = vars;
@@ -57,6 +57,11 @@ const styles = {
     },
 };
 
+const move = (arr, fromIndex, toIndex) => {
+    var element = arr[fromIndex];
+    arr.splice(fromIndex, 1);
+    arr.splice(toIndex, 0, element);
+}
 
 const ControlPanel = () => {
     const dispatch = useDispatch();
@@ -64,6 +69,7 @@ const ControlPanel = () => {
     const [open, setOpen] = useState(true);
     const activeAtlas = useSelector(state => state.viewer.atlas);
     const activeActivityMaps = useSelector(state => state.viewer.activityMaps);
+    const activityMapOrder = useSelector(state => state.viewer.order);
     const intensityRange = useSelector(state => state.viewer.activityMapsIntensityRange);
 
     const atlasesMetadata = useSelector(state => state.model.Atlases);
@@ -89,6 +95,9 @@ const ControlPanel = () => {
                 });
             }
 
+            // Rorder depending on the "order" from the store
+            viewerObjects.sort((a, b) => activityMapOrder.indexOf(a.id) - activityMapOrder.indexOf(b.id))
+
             // Atlas should be the last entry in the array
             const atlasId = activeAtlas.id;
             const atlasMetadata = atlasesMetadata[atlasId];
@@ -105,7 +114,6 @@ const ControlPanel = () => {
         }
         return viewerObjects
     }
-
 
     const computeGlobalIntensityRange = () => {
         let globalMin = Infinity;
@@ -127,12 +135,17 @@ const ControlPanel = () => {
         computeGlobalIntensityRange();
     }, [activeActivityMaps]);
 
-
     const onIntensityChange = (newValue) => {
         dispatch(changeAllActivityMapsIntensityRange(newValue));
     }
 
     const viewerObjects = getViewerObjectsData()
+
+    const onReorder = (source, target) => {
+        const suborder = activityMapOrder.slice(1, activityMapOrder.length)
+        move(suborder, source.index, target.index)
+        dispatch(changeViewerOrder([activityMapOrder[0], ...suborder]))
+    }
 
     return (
         <>
@@ -182,6 +195,7 @@ const ControlPanel = () => {
                     <Table
                         tableHeader={['Actions', 'Name', 'Configure intensity']}
                         tableContent={viewerObjects}
+                        onReorder={onReorder}
                     />
                 </Box>
             </Box>

--- a/client/src/components/Table.js
+++ b/client/src/components/Table.js
@@ -1,7 +1,8 @@
 import {Box, Typography} from "@mui/material";
-import React from "react";
+import React, { useRef } from "react";
 import vars from "../theme/variables";
 import TableRow from "./TableRow";
+
 
 const {
     headerBorderLeftColor,
@@ -121,8 +122,23 @@ export const tableStyles = {
     }
 };
 
-const Table = ({tableHeader, tableContent}) => {
+const Table = ({tableHeader, tableContent, onReorder}) => {
     const hasNoActivityMaps = tableContent.length < 2
+    const targetRow = useRef()
+    const sourceRow = useRef()
+
+    const dragStart = (id, index) => {
+        sourceRow.current = {id, index}
+    }
+
+    const dragEnter = (id, index) => {
+        targetRow.current = {id, index}
+    }
+
+    const dragEnd = () => {
+        onReorder(sourceRow.current, targetRow.current)
+    }
+
     return (
         <Box pb={1.5}>
             <Box sx={tableStyles.head}>
@@ -135,7 +151,8 @@ const Table = ({tableHeader, tableContent}) => {
 
             <Box sx={tableStyles.body}>
                 {tableContent?.map((row, index) =>
-                    <TableRow key={row.id} data={row} index={index} isAtlas={index === tableContent?.length - 1}/>)
+                    <TableRow key={row.id} data={row} index={index} isAtlas={index === tableContent?.length - 1}
+                              onDragStart={dragStart} onDragEnter={dragEnter} onDragEnd={dragEnd}/>)
                 }
                 {
                     hasNoActivityMaps &&

--- a/client/src/components/TableRow.js
+++ b/client/src/components/TableRow.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import {Box, Divider, IconButton, Tooltip, Typography} from "@mui/material";
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
@@ -29,7 +29,7 @@ const {
 } = vars;
 
 
-const TableRow = ({data, isAtlas}) => {
+const TableRow = ({ data, isAtlas, onDragStart, onDragEnter, onDragEnd, index }) => {
     const dispatch = useDispatch();
     const [anchorEl, setAnchorEl] = React.useState(null);
     const {id, name, intensityRange, stackIntensityRange, colorRange, isVisible, description} = data;
@@ -54,7 +54,11 @@ const TableRow = ({data, isAtlas}) => {
 
     return (
         <>
-            <Box sx={tableStyles.root}>
+            <Box sx={tableStyles.root}
+                 draggable={!isAtlas}
+                 onDragStart={e => onDragStart(id, index, e)}
+                 onDragEnter={e => onDragEnter(id, index, e)}
+                 onDragEnd={onDragEnd}>
                 <Box sx={{gap: '0.25rem !important'}}>
                     {/*TODO: Update title when feature gets implemented*/}
                     <Tooltip placement='right' title="Move up/down (Coming Soon)">

--- a/client/src/components/TableRow.js
+++ b/client/src/components/TableRow.js
@@ -55,14 +55,13 @@ const TableRow = ({ data, isAtlas, onDragStart, onDragEnter, onDragEnd, index })
     return (
         <>
             <Box sx={tableStyles.root}
-                 draggable={!isAtlas}
+                 draggable
                  onDragStart={e => onDragStart(id, index, e)}
                  onDragEnter={e => onDragEnter(id, index, e)}
                  onDragEnd={onDragEnd}>
                 <Box sx={{gap: '0.25rem !important'}}>
-                    {/*TODO: Update title when feature gets implemented*/}
                     <Tooltip placement='right' title="Move up/down">
-                        <IconButton disabled>
+                        <IconButton disabled={isAtlas}>
                             <DragIndicatorIcon/>
                         </IconButton>
                     </Tooltip>

--- a/client/src/components/TableRow.js
+++ b/client/src/components/TableRow.js
@@ -60,7 +60,7 @@ const TableRow = ({ data, isAtlas, onDragStart, onDragEnter, onDragEnd, index })
                  onDragEnter={e => onDragEnter(id, index, e)}
                  onDragEnd={onDragEnd}>
                 <Box sx={{gap: '0.25rem !important'}}>
-                    <Tooltip placement='right' title="Move up/down">
+                    <Tooltip placement='right' title={isAtlas ? "Not available for atlas" : "Move up/down"}>
                         <IconButton disabled={isAtlas}>
                             <DragIndicatorIcon/>
                         </IconButton>

--- a/client/src/components/TableRow.js
+++ b/client/src/components/TableRow.js
@@ -61,7 +61,7 @@ const TableRow = ({ data, isAtlas, onDragStart, onDragEnter, onDragEnd, index })
                  onDragEnd={onDragEnd}>
                 <Box sx={{gap: '0.25rem !important'}}>
                     {/*TODO: Update title when feature gets implemented*/}
-                    <Tooltip placement='right' title="Move up/down (Coming Soon)">
+                    <Tooltip placement='right' title="Move up/down">
                         <IconButton disabled>
                             <DragIndicatorIcon/>
                         </IconButton>

--- a/client/src/components/Viewer.js
+++ b/client/src/components/Viewer.js
@@ -34,6 +34,7 @@ export const Viewer = (props) => {
 
     const activeAtlas = useSelector(state => state.viewer.atlas);
     const activeActivityMaps = useSelector(state => state.viewer.activityMaps);
+    const activityMapsOrder = useSelector(state => state.viewer.order);
     const experimentsActivityMaps = useSelector(state => state.model.ExperimentsActivityMap);
     const currentExperiment = useSelector(state => state.currentExperiment);
     const activityMapsMetadata = useSelector(state => state.model.ActivityMaps);
@@ -271,7 +272,8 @@ export const Viewer = (props) => {
         Object.keys(activityMapsStackHelpersRef.current).forEach(amID => {
             const activityMap = activeActivityMaps[amID];
             if (activityMap) {
-                const activityMapStackHelper = activityMapsStackHelpersRef.current[amID]
+                const activityMapStackHelper = activityMapsStackHelpersRef.current[amID];
+                activityMapStackHelper.renderOrder = activityMapsOrder.indexOf(amID);
                 // change visibility
                 if (activityMapStackHelper.visible !== activityMap.visibility) {
                     activityMapStackHelper.visible = activityMap.visibility
@@ -289,7 +291,9 @@ export const Viewer = (props) => {
         activityMapsToAdd.forEach(amIdToAdd => {
             const activityMap = activeActivityMaps[amIdToAdd];
             let stackHelper = new StackHelper(activityMap.stack);
-            stackHelper.name = sceneObjects.ACTIVITY_MAP
+            stackHelper.userData['id'] = amIdToAdd;
+            stackHelper.name = sceneObjects.ACTIVITY_MAP;
+            stackHelper.renderOrder = activityMapsOrder.indexOf(amIdToAdd);
             stackHelper = postProcessActivityMap(stackHelper, activityMap, cameraRef.current.stackOrientation);
 
             sceneRef.current.add(stackHelper);
@@ -298,8 +302,11 @@ export const Viewer = (props) => {
             activityMapsStackHelpersRef.current[amIdToAdd] = stackHelper;
         });
 
+        // Reorder the scene manually regarding the renderOrder
+        // for some reasons it doesn't work automatically, even with the renderer initialized with "sortObject = true"
+        sceneRef.current.children.sort((a, b) => a.renderOrder - b.renderOrder)
 
-    }, [activeActivityMaps]);
+    }, [activeActivityMaps, activityMapsOrder]);
 
     useEffect(() => {
         if (currentAtlasStackHelperRef.current) {


### PR DESCRIPTION
Closes CFOS-71, allows one to reorder the different viewers and change the visibility rendering order.

https://github.com/MetaCell/cfos-visualizer/assets/2317394/0c3a767c-144d-46cd-a18b-37565097304b

